### PR TITLE
feat: create pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,9 +1,15 @@
-- id: tfclean
-  name: TFClean
+---
+- additional_dependencies:
+    - ./cmd/tfclean
+  alias: tfclean
+  args:
+    - .
   description: Remove applied moved block, import block, etc
-  entry: ./cmd/tfclean/main.go
-  language: golang
-  require_serial: false
-  pass_filenames: true
-  files: \.((tf|tofu)(vars)?|hcl)$
+  entry: tfclean
   exclude: \.terraform\/.*$
+  files: \.((tf|tofu)(vars)?|hcl)$
+  id: tfclean
+  language: golang
+  name: TFClean
+  pass_filenames: false
+  require_serial: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: tfclean
+  name: TFClean
+  description: Remove applied moved block, import block, etc
+  entry: ./cmd/tfclean/main.go
+  language: golang
+  require_serial: false
+  pass_filenames: true
+  files: \.((tf|tofu)(vars)?|hcl)$
+  exclude: \.terraform\/.*$


### PR DESCRIPTION
The essence of this pull request is to allow the downstream clients to use the following syntax in their pre-commit configs:

```yaml
# .pre-commit-config.yaml
repos:
# ... truncated ...
  - repo: https://github.com/takaishi/tfclean
    rev: v0.0.9
    hooks:
      - id: tfclean
```

At the moment and where it stands, it's doing nothing because in the `args` section, the root of the repository is being passed to the `tfclean` binary.

https://github.com/takaishi/tfclean/blob/e49d51ec74dc3b025574229dbfe9c84fbe48b038/.pre-commit-hooks.yaml#L5-L6

Additionally, `tfclean` at the moment does not support `pass_filenames` and will complain with an error saying that it was expecting directory instead of filename:

```plaintext
error parsing CLI: unexpected argument example/variables.tf       
2025/02/07 09:43:29 error: error parsing CLI: unexpected argument example/variables.tf
```

My suggestion is to add support for `-r | --recursive` to the binary so that within the `.pre-commit-hooks.yaml`, we can specify `-r` to the `args` attribute, letting `tfclean` to run against the entire codebase.

Another suggestion would be to be able to receive filenames as arguments and find their basename from inside the `tfclean`.

I am open to contribute further to support either of these cases.

Cheers. :clinking_glasses: 
