### PR TITLE
Add a SECURITY.md file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Security vulnerabilities can be privately reported via the security tab in GitHub:
+https://github.com/takaishi/tfclean/security


### PR DESCRIPTION
I DO NOT have a security venerability to report!

This repo is currently scoring low in our internal scans due to a number of missing security features.
One of those is that `Private vulnerability reporting` is not enabled, and there is no SECURITY.md file.

Would it be ok to enable them on the following page:
https://github.com/takaishi/tfclean/security
See:
<img width="1135" height="89" alt="Screenshot 2026-02-18 at 11 53 13" src="https://github.com/user-attachments/assets/c62152f0-73c9-4e02-aec8-75f3f1b9825f" />

And then adding this `SECURITY.md` file so users know how to use it.

To confirm - I don't have any security concerns - but having an ability to privately report these is a requirement for open source projects we use!