### PR TITLE
Fix moved and removed checks for root resources

### DIFF
--- a/app.go
+++ b/app.go
@@ -246,7 +246,7 @@ func (app *App) movedImportIsApplied(state *tfstate.TFState, to string) (bool, e
 }
 
 func (app *App) movedBlockIsApplied(state *tfstate.TFState, from string, to string) (bool, error) {
-	if len(strings.Split(from, ".")) == 2 && len(strings.Split(to, ".")) == 2 {
+	if strings.HasPrefix(from, "module.") && strings.HasPrefix(to, "module.") && len(strings.Split(from, ".")) == 2 && len(strings.Split(to, ".")) == 2 {
 		// from and to is module
 		names, err := state.List()
 		if err != nil {
@@ -291,7 +291,7 @@ func (app *App) movedBlockIsApplied(state *tfstate.TFState, from string, to stri
 }
 
 func (app *App) removedBlockIsApplied(state *tfstate.TFState, from string) (bool, error) {
-	if len(strings.Split(from, ".")) == 2 {
+	if strings.HasPrefix(from, "module.") && len(strings.Split(from, ".")) == 2 {
 		names, err := state.List()
 		if err != nil {
 			return false, err

--- a/moved_test.go
+++ b/moved_test.go
@@ -2,8 +2,10 @@ package tfclean
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/fujiwara/tfstate-lookup/tfstate"
 	"github.com/hashicorp/hcl/v2/hclparse"
 )
 
@@ -13,7 +15,8 @@ func TestApp_applyMovedDeletion(t *testing.T) {
 		CLI       *CLI
 	}
 	type args struct {
-		data []byte
+		data  []byte
+		state string
 	}
 	tests := []struct {
 		name    string
@@ -123,6 +126,228 @@ resource "null_resource" "bbb" {}
 `),
 			wantErr: false,
 		},
+		{
+			name:   "resource has not been moved",
+			fields: fields{},
+			args: args{
+				data: []byte(`
+resource "time_static" "bbb" {}
+
+moved {
+  from = time_static.aaa
+  to   = time_static.bbb
+}
+`),
+				state: `
+{
+  "version": 4,
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "time_static",
+      "name": "aaa",
+      "provider": "provider[\"registry.terraform.io/hashicorp/time\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "day": 13,
+            "hour": 13,
+            "id": "2026-05-13T13:49:53Z",
+            "minute": 49,
+            "month": 5,
+            "rfc3339": "2026-05-13T13:49:53Z",
+            "second": 53,
+            "triggers": null,
+            "unix": 1778680193,
+            "year": 2026
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ]
+}
+`,
+			},
+			want: []byte(`
+resource "time_static" "bbb" {}
+
+moved {
+  from = time_static.aaa
+  to   = time_static.bbb
+}
+`),
+			wantErr: false,
+		},
+		{
+			name:   "resource has been moved",
+			fields: fields{},
+			args: args{
+				data: []byte(`
+resource "time_static" "bbb" {}
+
+moved {
+  from = time_static.aaa
+  to   = time_static.bbb
+}
+`),
+				state: `
+{
+  "version": 4,
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "time_static",
+      "name": "bbb",
+      "provider": "provider[\"registry.terraform.io/hashicorp/time\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "day": 13,
+            "hour": 13,
+            "id": "2026-05-13T13:49:53Z",
+            "minute": 49,
+            "month": 5,
+            "rfc3339": "2026-05-13T13:49:53Z",
+            "second": 53,
+            "triggers": null,
+            "unix": 1778680193,
+            "year": 2026
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ]
+}
+`,
+			},
+			want: []byte(`
+resource "time_static" "bbb" {}
+
+`),
+			wantErr: false,
+		},
+		{
+			name:   "module has not been moved",
+			fields: fields{},
+			args: args{
+				data: []byte(`
+module "bbb" {
+  source = "./modules/time"
+}
+
+moved {
+  from = module.aaa
+  to   = module.bbb
+}
+`),
+				state: `
+{
+  "version": 4,
+  "resources": [
+    {
+      "module": "module.aaa",
+      "mode": "managed",
+      "type": "time_static",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/time\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "day": 13,
+            "hour": 14,
+            "id": "2026-05-13T14:13:00Z",
+            "minute": 13,
+            "month": 5,
+            "rfc3339": "2026-05-13T14:13:00Z",
+            "second": 0,
+            "triggers": null,
+            "unix": 1778681580,
+            "year": 2026
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ]
+}
+`,
+			},
+			want: []byte(`
+module "bbb" {
+  source = "./modules/time"
+}
+
+moved {
+  from = module.aaa
+  to   = module.bbb
+}
+`),
+			wantErr: false,
+		},
+		{
+			name:   "module has been moved",
+			fields: fields{},
+			args: args{
+				data: []byte(`
+module "bbb" {
+  source = "./modules/time"
+}
+
+moved {
+  from = module.aaa
+  to   = module.bbb
+}
+`),
+				state: `
+{
+  "version": 4,
+  "resources": [
+    {
+      "module": "module.bbb",
+      "mode": "managed",
+      "type": "time_static",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/time\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "day": 13,
+            "hour": 14,
+            "id": "2026-05-13T14:13:00Z",
+            "minute": 13,
+            "month": 5,
+            "rfc3339": "2026-05-13T14:13:00Z",
+            "second": 0,
+            "triggers": null,
+            "unix": 1778681580,
+            "year": 2026
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ]
+}
+`,
+			},
+			want: []byte(`
+module "bbb" {
+  source = "./modules/time"
+}
+
+`),
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -130,7 +355,15 @@ resource "null_resource" "bbb" {}
 				hclParser: tt.fields.hclParser,
 				CLI:       tt.fields.CLI,
 			}
-			got, err := app.applyAllDeletions(tt.args.data, nil)
+			var state *tfstate.TFState
+			if tt.args.state != "" {
+				var err error
+				state, err = tfstate.Read(t.Context(), strings.NewReader(tt.args.state))
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := app.applyAllDeletions(tt.args.data, state)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("applyAllDeletions() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/removed_test.go
+++ b/removed_test.go
@@ -2,8 +2,10 @@ package tfclean
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/fujiwara/tfstate-lookup/tfstate"
 	"github.com/hashicorp/hcl/v2/hclparse"
 )
 
@@ -13,7 +15,8 @@ func TestApp_applyRemovedDeletion(t *testing.T) {
 		CLI       *CLI
 	}
 	type args struct {
-		data []byte
+		data  []byte
+		state string
 	}
 	tests := []struct {
 		name    string
@@ -140,6 +143,169 @@ resource "null_resource" "bbb" {}
 `),
 			wantErr: false,
 		},
+		{
+			name:   "resource has not been removed",
+			fields: fields{},
+			args: args{
+				data: []byte(`
+resource "time_static" "bbb" {}
+
+removed {
+  from = time_static.aaa
+}
+`),
+				state: `
+{
+  "version": 4,
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "time_static",
+      "name": "aaa",
+      "provider": "provider[\"registry.terraform.io/hashicorp/time\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "day": 13,
+            "hour": 13,
+            "id": "2026-05-13T13:49:53Z",
+            "minute": 49,
+            "month": 5,
+            "rfc3339": "2026-05-13T13:49:53Z",
+            "second": 53,
+            "triggers": null,
+            "unix": 1778680193,
+            "year": 2026
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ]
+}
+`,
+			},
+			want: []byte(`
+resource "time_static" "bbb" {}
+
+removed {
+  from = time_static.aaa
+}
+`),
+			wantErr: false,
+		},
+		{
+			name:   "resource has been removed",
+			fields: fields{},
+			args: args{
+				data: []byte(`
+resource "time_static" "bbb" {}
+
+removed {
+  from = time_static.aaa
+}
+`),
+				state: `
+{
+  "version": 4,
+  "resources": []
+}
+`,
+			},
+			want: []byte(`
+resource "time_static" "bbb" {}
+
+`),
+			wantErr: false,
+		},
+		{
+			name:   "module has not been removed",
+			fields: fields{},
+			args: args{
+				data: []byte(`
+module "bbb" {
+  source = "./modules/time"
+}
+
+removed {
+  from = module.aaa
+}
+`),
+				state: `
+{
+  "version": 4,
+  "resources": [
+    {
+      "module": "module.aaa",
+      "mode": "managed",
+      "type": "time_static",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/time\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "day": 13,
+            "hour": 14,
+            "id": "2026-05-13T14:13:00Z",
+            "minute": 13,
+            "month": 5,
+            "rfc3339": "2026-05-13T14:13:00Z",
+            "second": 0,
+            "triggers": null,
+            "unix": 1778681580,
+            "year": 2026
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ]
+}
+`,
+			},
+			want: []byte(`
+module "bbb" {
+  source = "./modules/time"
+}
+
+removed {
+  from = module.aaa
+}
+`),
+			wantErr: false,
+		},
+		{
+			name:   "module has been removed",
+			fields: fields{},
+			args: args{
+				data: []byte(`
+module "bbb" {
+  source = "./modules/time"
+}
+
+removed {
+  from = module.aaa
+}
+`),
+				state: `
+{
+  "version": 4,
+  "resources": []
+}
+`,
+			},
+			want: []byte(`
+module "bbb" {
+  source = "./modules/time"
+}
+
+`),
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -147,7 +313,15 @@ resource "null_resource" "bbb" {}
 				hclParser: tt.fields.hclParser,
 				CLI:       tt.fields.CLI,
 			}
-			got, err := app.applyAllDeletions(tt.args.data, nil)
+			var state *tfstate.TFState
+			if tt.args.state != "" {
+				var err error
+				state, err = tfstate.Read(t.Context(), strings.NewReader(tt.args.state))
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := app.applyAllDeletions(tt.args.data, state)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("applyAllDeletions() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Root resource addresses such as `time_static.aaa` have two path segments, just like `module.foo`. The old applied checks treated any two-segment address as a whole-module move or removal, so tfclean could delete moved or removed blocks before the resource had actually been moved or removed.

## Steps to reproduce

### 1. Create time_static.aaa

```terraform
resource "time_static" "aaa" {}
```

### 2. Rename time_static.aaa to time_static.bbb with moved block

```terraform
resource "time_static" "bbb" {}

moved {
  from = time_static.aaa
  to   = time_static.bbb
}
```

### 3. Run tfclean

```sh
./dist/tfclean tf --tfstate file://$PWD/terraform.tfstate
```

Before this change, the command above incorrectly removes the moved block.

With this PR, the moved block is preserved until the resource move has actually been applied.
