### PR TITLE
feat: Delete .tf files that become empty after cleaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ AWS_PROFILE=your_profile tfclean /path/to/tffiles
 AWS_PROFILE=your_profile tfclean --tfstate s3://path/to/tfstate /path/to/tffiles
 ```
 
+### Empty File Cleanup
+
+If cleaning removes the last block from a `.tf` file and leaves nothing but whitespace or comments, tfclean deletes the file. Files that were already empty/comment-only before the run are left untouched. Deletions show up as deleted files in `git status` and need to be staged like any other change.
+
 ## Features
 
 - **Smart Block Removal**
@@ -90,6 +94,7 @@ AWS_PROFILE=your_profile tfclean --tfstate s3://path/to/tfstate /path/to/tffiles
   - [x] Removes import blocks that have been applied
   - [x] Removes removed blocks that have been applied
   - [x] Option to forcefully remove all moved/import/removed blocks
+  - [x] Deletes `.tf` files that become empty (or only whitespace/comments) as a result of cleaning
 
 - **Platform Support**
   - Supports both x86_64 and ARM64 architectures

--- a/app.go
+++ b/app.go
@@ -1,6 +1,7 @@
 package tfclean
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log"
@@ -73,15 +74,42 @@ func (app *App) Run(ctx context.Context) error {
 }
 
 func (app *App) processFile(path string, state *tfstate.TFState) error {
-	data, err := os.ReadFile(path)
+	original, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
 
-	if data, err = app.applyAllDeletions(data, state); err != nil {
+	data, err := app.applyAllDeletions(original, state)
+	if err != nil {
 		return err
 	}
+
+	if !bytes.Equal(data, original) {
+		empty, err := app.isEmptyConfig(data)
+		if err != nil {
+			return err
+		}
+		if empty {
+			return os.Remove(path)
+		}
+	}
 	return os.WriteFile(path, data, 0644)
+}
+
+func (app *App) isEmptyConfig(data []byte) (bool, error) {
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return true, nil
+	}
+	parser := hclparse.NewParser()
+	hclFile, diags := parser.ParseHCL(data, "memory.tf")
+	if diags.HasErrors() {
+		return false, fmt.Errorf("error parsing HCL: %s", diags)
+	}
+	body, ok := hclFile.Body.(*hclsyntax.Body)
+	if !ok {
+		return false, nil
+	}
+	return len(body.Blocks) == 0 && len(body.Attributes) == 0, nil
 }
 
 func (app *App) collectDeletionRanges(body *hclsyntax.Body, state *tfstate.TFState) ([]hcl.Range, error) {

--- a/empty_file_test.go
+++ b/empty_file_test.go
@@ -1,0 +1,90 @@
+package tfclean
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestApp_processFile_deletesEmptyFile(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		wantDeleted bool
+		wantContent string
+	}{
+		{
+			name:        "file becomes empty after removing all blocks",
+			content:     "moved {\n  from = module.foo[\"hoge\"]\n  to   = module.foo[\"piyo\"]\n}\n",
+			wantDeleted: true,
+		},
+		{
+			name:        "file becomes comments-only after cleaning",
+			content:     "# header\nmoved {\n  from = module.foo[\"a\"]\n  to   = module.foo[\"b\"]\n}\n",
+			wantDeleted: true,
+		},
+		{
+			name:        "pre-existing whitespace-only file is preserved",
+			content:     "   \n\n\t\n",
+			wantDeleted: false,
+			wantContent: "   \n\n\t\n",
+		},
+		{
+			name:        "pre-existing zero-byte file is preserved",
+			content:     "",
+			wantDeleted: false,
+			wantContent: "",
+		},
+		{
+			name:        "pre-existing comments-only file is preserved",
+			content:     "# just a note\n// another note\n",
+			wantDeleted: false,
+			wantContent: "# just a note\n// another note\n",
+		},
+		{
+			name:        "pre-existing block-comment-only file is preserved",
+			content:     "/* nothing\n   to see here */\n",
+			wantDeleted: false,
+			wantContent: "/* nothing\n   to see here */\n",
+		},
+		{
+			name:        "file with remaining resource is kept",
+			content:     "resource \"null_resource\" \"keep\" {}\nmoved {\n  from = module.foo[\"a\"]\n  to   = module.foo[\"b\"]\n}\n",
+			wantDeleted: false,
+			wantContent: "resource \"null_resource\" \"keep\" {}\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "test.tf")
+			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
+				t.Fatalf("write fixture: %v", err)
+			}
+
+			app := New(&CLI{Dir: dir})
+			if err := app.processFile(path, nil); err != nil {
+				t.Fatalf("processFile: %v", err)
+			}
+
+			_, err := os.Stat(path)
+			if tt.wantDeleted {
+				if !os.IsNotExist(err) {
+					t.Fatalf("expected file to be deleted, stat err = %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected file to exist, got err = %v", err)
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			if string(got) != tt.wantContent {
+				t.Errorf("content mismatch\n got: %q\nwant: %q", string(got), tt.wantContent)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When cleaning removes the last block from a file and only whitespace or comments remain, the file is now removed instead of being rewritten as an empty placeholder. Files that were already empty/comment-only before cleaning are left untouched.