### PR TITLE
Add tfclean-ignore and tfclean-ignore-file comment annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,26 @@ AWS_PROFILE=your_profile tfclean --tfstate s3://path/to/tfstate /path/to/tffiles
 
 If cleaning removes the last block from a `.tf` file and leaves nothing but whitespace or comments, tfclean deletes the file. Files that were already empty/comment-only before the run are left untouched. Deletions show up as deleted files in `git status` and need to be staged like any other change.
 
+### Ignoring Blocks and Files
+
+Sometimes you want to keep a `moved`, `import`, or `removed` block around even though tfclean would otherwise remove it. Add a `# tfclean-ignore` comment on the line immediately before the block:
+
+```hcl
+# tfclean-ignore: reused across workspaces, keep until the last one is migrated
+import {
+  to = aws_athena_workgroup.primary
+  id = "primary"
+}
+```
+
+The reason after the colon is optional but recommended so future readers understand the intent.
+
+To skip an entire file, add a `# tfclean-ignore-file` comment anywhere in it:
+
+```hcl
+# tfclean-ignore-file
+```
+
 ## Features
 
 - **Smart Block Removal**
@@ -95,6 +115,7 @@ If cleaning removes the last block from a `.tf` file and leaves nothing but whit
   - [x] Removes removed blocks that have been applied
   - [x] Option to forcefully remove all moved/import/removed blocks
   - [x] Deletes `.tf` files that become empty (or only whitespace/comments) as a result of cleaning
+  - [x] `# tfclean-ignore` / `# tfclean-ignore-file` comment annotations to preserve specific blocks or whole files
 
 - **Platform Support**
   - Supports both x86_64 and ARM64 architectures

--- a/app.go
+++ b/app.go
@@ -112,9 +112,44 @@ func (app *App) isEmptyConfig(data []byte) (bool, error) {
 	return len(body.Blocks) == 0 && len(body.Attributes) == 0, nil
 }
 
-func (app *App) collectDeletionRanges(body *hclsyntax.Body, state *tfstate.TFState) ([]hcl.Range, error) {
+const (
+	ignoreFileAnnotation = "tfclean-ignore-file"
+	ignoreAnnotation     = "tfclean-ignore"
+)
+
+// collectIgnoreAnnotations scans data for tfclean-ignore and tfclean-ignore-file
+// comment annotations. It reports whether the whole file should be left untouched,
+// and the set of line numbers carrying a block-level ignore annotation (the line
+// immediately preceding the block a user wants to preserve).
+func (app *App) collectIgnoreAnnotations(data []byte) (bool, map[int]bool, error) {
+	tokens, diags := hclsyntax.LexConfig(data, "memory.tf", hcl.InitialPos)
+	if diags.HasErrors() {
+		return false, nil, fmt.Errorf("error lexing HCL: %s", diags)
+	}
+
+	fileIgnored := false
+	ignoredLines := make(map[int]bool)
+	for _, token := range tokens {
+		if token.Type != hclsyntax.TokenComment {
+			continue
+		}
+		text := string(token.Bytes)
+		switch {
+		case strings.Contains(text, ignoreFileAnnotation):
+			fileIgnored = true
+		case strings.Contains(text, ignoreAnnotation):
+			ignoredLines[token.Range.Start.Line] = true
+		}
+	}
+	return fileIgnored, ignoredLines, nil
+}
+
+func (app *App) collectDeletionRanges(body *hclsyntax.Body, state *tfstate.TFState, ignoredLines map[int]bool) ([]hcl.Range, error) {
 	ranges := make([]hcl.Range, 0, len(body.Blocks))
 	for _, block := range body.Blocks {
+		if ignoredLines[block.Range().Start.Line-1] {
+			continue
+		}
 		switch block.Type {
 		case "import":
 			to, _ := app.getValueFromAttribute(block.Body.Attributes["to"])
@@ -165,6 +200,13 @@ func (app *App) applyAllDeletions(data []byte, state *tfstate.TFState) ([]byte, 
 	if len(data) == 0 {
 		return data, nil
 	}
+	fileIgnored, ignoredLines, err := app.collectIgnoreAnnotations(data)
+	if err != nil {
+		return nil, err
+	}
+	if fileIgnored {
+		return data, nil
+	}
 	// Create a new parser each time to avoid the influence of previous parse results
 	parser := hclparse.NewParser()
 	hclFile, diags := parser.ParseHCL(data, "memory.tf")
@@ -175,7 +217,7 @@ func (app *App) applyAllDeletions(data []byte, state *tfstate.TFState) ([]byte, 
 	if !ok {
 		return data, nil
 	}
-	ranges, err := app.collectDeletionRanges(body, state)
+	ranges, err := app.collectDeletionRanges(body, state, ignoredLines)
 	if err != nil {
 		return nil, err
 	}

--- a/ignore_test.go
+++ b/ignore_test.go
@@ -1,0 +1,187 @@
+package tfclean
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestApp_applyAllDeletions_ignoreAnnotations(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name: "tfclean-ignore preserves the import block immediately below it",
+			data: []byte(`
+resource "null_resource" "aaa" {}
+# tfclean-ignore: keep this for a follow-up change
+import {
+  id = "resource_id"
+  to = module.foo.hoge
+}
+resource "null_resource" "bbb" {}
+`),
+			want: []byte(`
+resource "null_resource" "aaa" {}
+# tfclean-ignore: keep this for a follow-up change
+import {
+  id = "resource_id"
+  to = module.foo.hoge
+}
+resource "null_resource" "bbb" {}
+`),
+			wantErr: false,
+		},
+		{
+			name: "tfclean-ignore without a reason still preserves the block",
+			data: []byte(`
+resource "null_resource" "aaa" {}
+# tfclean-ignore
+import {
+  id = "resource_id"
+  to = module.foo.hoge
+}
+resource "null_resource" "bbb" {}
+`),
+			want: []byte(`
+resource "null_resource" "aaa" {}
+# tfclean-ignore
+import {
+  id = "resource_id"
+  to = module.foo.hoge
+}
+resource "null_resource" "bbb" {}
+`),
+			wantErr: false,
+		},
+		{
+			name: "only the annotated block is preserved, others are still removed",
+			data: []byte(`
+resource "null_resource" "aaa" {}
+import {
+  id = "1234567890:default:hoge"
+  to = module.foo["hoge"]
+}
+# tfclean-ignore: keep this one
+import {
+  id = "1234567890:default:piyo"
+  to = module.foo["piyo"]
+}
+resource "null_resource" "bbb" {}
+`),
+			want: []byte(`
+resource "null_resource" "aaa" {}
+# tfclean-ignore: keep this one
+import {
+  id = "1234567890:default:piyo"
+  to = module.foo["piyo"]
+}
+resource "null_resource" "bbb" {}
+`),
+			wantErr: false,
+		},
+		{
+			name: "tfclean-ignore only applies to the block on the immediately following line",
+			data: []byte(`
+resource "null_resource" "aaa" {}
+# tfclean-ignore: reason
+
+import {
+  id = "resource_id"
+  to = module.foo.hoge
+}
+resource "null_resource" "bbb" {}
+`),
+			want: []byte(`
+resource "null_resource" "aaa" {}
+# tfclean-ignore: reason
+
+resource "null_resource" "bbb" {}
+`),
+			wantErr: false,
+		},
+		{
+			name: "tfclean-ignore preserves moved blocks",
+			data: []byte(`
+resource "null_resource" "aaa" {}
+# tfclean-ignore
+moved {
+  from = null_resource.old
+  to   = null_resource.aaa
+}
+resource "null_resource" "bbb" {}
+`),
+			want: []byte(`
+resource "null_resource" "aaa" {}
+# tfclean-ignore
+moved {
+  from = null_resource.old
+  to   = null_resource.aaa
+}
+resource "null_resource" "bbb" {}
+`),
+			wantErr: false,
+		},
+		{
+			name: "tfclean-ignore preserves removed blocks",
+			data: []byte(`
+# tfclean-ignore
+removed {
+  from = null_resource.old
+
+  lifecycle {
+    destroy = false
+  }
+}
+resource "null_resource" "bbb" {}
+`),
+			want: []byte(`
+# tfclean-ignore
+removed {
+  from = null_resource.old
+
+  lifecycle {
+    destroy = false
+  }
+}
+resource "null_resource" "bbb" {}
+`),
+			wantErr: false,
+		},
+		{
+			name: "tfclean-ignore-file leaves the whole file untouched",
+			data: []byte(`# tfclean-ignore-file
+resource "null_resource" "aaa" {}
+import {
+  id = "resource_id"
+  to = module.foo.hoge
+}
+resource "null_resource" "bbb" {}
+`),
+			want: []byte(`# tfclean-ignore-file
+resource "null_resource" "aaa" {}
+import {
+  id = "resource_id"
+  to = module.foo.hoge
+}
+resource "null_resource" "bbb" {}
+`),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := &App{}
+			got, err := app.applyAllDeletions(tt.data, nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("applyAllDeletions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("applyAllDeletions() got = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `# tfclean-ignore` comment annotation to preserve a specific `moved`/`import`/`removed` block from cleanup (must be on the line immediately before the block; a reason after `:` is optional)
- Add `# tfclean-ignore-file` comment annotation to skip processing an entire file
- Follows the convention established by tflint's `tflint-ignore` / `tflint-ignore-file`

Closes #90

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] Added `ignore_test.go` covering: block-level ignore with/without reason, ignoring only one of several blocks, ignore only applying to the immediately preceding line (not across blank lines), moved/removed block ignore, and file-level ignore