### PR TITLE
Support multiple tfstate files with AND semantics (#84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ AWS_PROFILE=your_profile tfclean /path/to/tffiles
 AWS_PROFILE=your_profile tfclean --tfstate s3://path/to/tfstate /path/to/tffiles
 ```
 
+### Multiple tfstate Files
+
+When the same Terraform configuration is backed by several states — for example one per developer, per PR, and dev/prod — pass `--tfstate` multiple times. A block is removed only if it has been applied in **all** of the given states; if it is still pending in any one of them, tfclean keeps it.
+
+```bash
+tfclean \
+  --tfstate s3://path/to/dev-alice.tfstate \
+  --tfstate s3://path/to/dev-bob.tfstate \
+  --tfstate s3://path/to/prod.tfstate \
+  /path/to/tffiles
+```
+
+In the example above, a `moved` block that has been applied to `dev-alice` and `prod` but not yet to `dev-bob` is preserved until it is applied everywhere. Because dropping a state could remove a block that is still pending elsewhere, tfclean treats a failure to read any explicitly given state as a fatal error rather than silently skipping it.
+
+Auto-detection only resolves a single backend from your `.tf` files, so multiple states must be specified explicitly with `--tfstate`.
+
 ### Empty File Cleanup
 
 If cleaning removes the last block from a `.tf` file and leaves nothing but whitespace or comments, tfclean deletes the file. Files that were already empty/comment-only before the run are left untouched. Deletions show up as deleted files in `git status` and need to be staged like any other change.

--- a/app.go
+++ b/app.go
@@ -30,13 +30,18 @@ func New(cli *CLI) *App {
 }
 
 func (app *App) Run(ctx context.Context) error {
-	var err error
-	var state *tfstate.TFState
+	var states []*tfstate.TFState
 
-	if app.CLI.Tfstate != "" {
-		state, err = tfstate.ReadURL(ctx, app.CLI.Tfstate)
-		if err != nil {
-			return err
+	if len(app.CLI.Tfstate) > 0 {
+		// States given explicitly. A read failure is a hard error: silently
+		// dropping a state would shrink the set we require agreement across and
+		// could delete a block that is still unapplied in the dropped state.
+		for _, url := range app.CLI.Tfstate {
+			state, err := tfstate.ReadURL(ctx, url)
+			if err != nil {
+				return fmt.Errorf("could not read state from %s: %w", url, err)
+			}
+			states = append(states, state)
 		}
 	} else {
 		detectedURL, err := app.detectBackendFromConfig()
@@ -45,10 +50,12 @@ func (app *App) Run(ctx context.Context) error {
 			log.Printf("Continuing without state file. Use --tfstate flag to specify state location manually.")
 		} else if detectedURL != "" {
 			log.Printf("Auto-detected state location: %s", detectedURL)
-			state, err = tfstate.ReadURL(ctx, detectedURL)
+			state, err := tfstate.ReadURL(ctx, detectedURL)
 			if err != nil {
 				log.Printf("Warning: Could not read state from auto-detected location: %v", err)
 				log.Printf("Continuing without state file.")
+			} else {
+				states = append(states, state)
 			}
 		}
 	}
@@ -64,7 +71,7 @@ func (app *App) Run(ctx context.Context) error {
 		}
 		if filepath.Ext(file.Name()) == ".tf" {
 			path := filepath.Join(app.CLI.Dir, file.Name())
-			err := app.processFile(path, state)
+			err := app.processFile(path, states)
 			if err != nil {
 				return err
 			}
@@ -73,13 +80,13 @@ func (app *App) Run(ctx context.Context) error {
 	return nil
 }
 
-func (app *App) processFile(path string, state *tfstate.TFState) error {
+func (app *App) processFile(path string, states []*tfstate.TFState) error {
 	original, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
 
-	data, err := app.applyAllDeletions(original, state)
+	data, err := app.applyAllDeletions(original, states)
 	if err != nil {
 		return err
 	}
@@ -144,59 +151,63 @@ func (app *App) collectIgnoreAnnotations(data []byte) (bool, map[int]bool, error
 	return fileIgnored, ignoredLines, nil
 }
 
-func (app *App) collectDeletionRanges(body *hclsyntax.Body, state *tfstate.TFState, ignoredLines map[int]bool) ([]hcl.Range, error) {
+// appliedInAll reports whether check returns true for every state. With no
+// states it returns true so callers fall back to removing the block
+// unconditionally (the "remove all" / forced mode). When several states are
+// given, a block counts as applied only if it is applied in all of them, so a
+// block still pending in any one state is preserved.
+func (app *App) appliedInAll(states []*tfstate.TFState, check func(*tfstate.TFState) (bool, error)) (bool, error) {
+	for _, state := range states {
+		applied, err := check(state)
+		if err != nil {
+			return false, err
+		}
+		if !applied {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (app *App) collectDeletionRanges(body *hclsyntax.Body, states []*tfstate.TFState, ignoredLines map[int]bool) ([]hcl.Range, error) {
 	ranges := make([]hcl.Range, 0, len(body.Blocks))
 	for _, block := range body.Blocks {
 		if ignoredLines[block.Range().Start.Line-1] {
 			continue
 		}
+		var applied bool
+		var err error
 		switch block.Type {
 		case "import":
 			to, _ := app.getValueFromAttribute(block.Body.Attributes["to"])
-			if state != nil {
-				applied, err := app.movedImportIsApplied(state, to)
-				if err != nil {
-					return nil, err
-				}
-				if applied {
-					ranges = append(ranges, block.Range())
-				}
-			} else {
-				ranges = append(ranges, block.Range())
-			}
+			applied, err = app.appliedInAll(states, func(state *tfstate.TFState) (bool, error) {
+				return app.movedImportIsApplied(state, to)
+			})
 		case "moved":
 			from, _ := app.getValueFromAttribute(block.Body.Attributes["from"])
 			to, _ := app.getValueFromAttribute(block.Body.Attributes["to"])
-			if state != nil {
-				applied, err := app.movedBlockIsApplied(state, from, to)
-				if err != nil {
-					return nil, err
-				}
-				if applied {
-					ranges = append(ranges, block.Range())
-				}
-			} else {
-				ranges = append(ranges, block.Range())
-			}
+			applied, err = app.appliedInAll(states, func(state *tfstate.TFState) (bool, error) {
+				return app.movedBlockIsApplied(state, from, to)
+			})
 		case "removed":
 			from, _ := app.getValueFromAttribute(block.Body.Attributes["from"])
-			if state != nil {
-				applied, err := app.removedBlockIsApplied(state, from)
-				if err != nil {
-					return nil, err
-				}
-				if applied {
-					ranges = append(ranges, block.Range())
-				}
-			} else {
-				ranges = append(ranges, block.Range())
-			}
+			applied, err = app.appliedInAll(states, func(state *tfstate.TFState) (bool, error) {
+				return app.removedBlockIsApplied(state, from)
+			})
+		default:
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		if applied {
+			ranges = append(ranges, block.Range())
 		}
 	}
 	return ranges, nil
 }
 
-func (app *App) applyAllDeletions(data []byte, state *tfstate.TFState) ([]byte, error) {
+func (app *App) applyAllDeletions(data []byte, states []*tfstate.TFState) ([]byte, error) {
 	if len(data) == 0 {
 		return data, nil
 	}
@@ -217,7 +228,7 @@ func (app *App) applyAllDeletions(data []byte, state *tfstate.TFState) ([]byte, 
 	if !ok {
 		return data, nil
 	}
-	ranges, err := app.collectDeletionRanges(body, state, ignoredLines)
+	ranges, err := app.collectDeletionRanges(body, states, ignoredLines)
 	if err != nil {
 		return nil, err
 	}

--- a/cli.go
+++ b/cli.go
@@ -13,7 +13,7 @@ type GlobalOptions struct {
 }
 
 type CLI struct {
-	Tfstate string      `help:"Terraform state file (optional; S3 backend is auto-detected from .tf files in the given directory)"`
+	Tfstate []string    `help:"Terraform state file (repeatable; S3 backend is auto-detected from .tf files when omitted). When multiple states are given, a block is removed only if it has been applied in all of them."`
 	Dir     string      `arg:"" required:"" help:"Directory to clean"`
 	Version VersionFlag `name:"version" help:"show version"`
 }

--- a/moved_test.go
+++ b/moved_test.go
@@ -386,15 +386,15 @@ module "bbb" {
 				hclParser: tt.fields.hclParser,
 				CLI:       tt.fields.CLI,
 			}
-			var state *tfstate.TFState
+			var states []*tfstate.TFState
 			if tt.args.state != "" {
-				var err error
-				state, err = tfstate.Read(t.Context(), strings.NewReader(tt.args.state))
+				state, err := tfstate.Read(t.Context(), strings.NewReader(tt.args.state))
 				if err != nil {
 					t.Fatal(err)
 				}
+				states = append(states, state)
 			}
-			got, err := app.applyAllDeletions(tt.args.data, state)
+			got, err := app.applyAllDeletions(tt.args.data, states)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("applyAllDeletions() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/multiple_tfstate_test.go
+++ b/multiple_tfstate_test.go
@@ -1,0 +1,111 @@
+package tfclean
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/fujiwara/tfstate-lookup/tfstate"
+	"github.com/hashicorp/hcl/v2/hclparse"
+)
+
+// stateWithResource returns a minimal Terraform state JSON containing a single
+// time_static resource with the given name. It is used to model "the move has
+// (not) been applied in this state": when the moved-to resource is present the
+// move is applied, otherwise it is still pending.
+func stateWithResource(name string) string {
+	return `
+{
+  "version": 4,
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "time_static",
+      "name": "` + name + `",
+      "provider": "provider[\"registry.terraform.io/hashicorp/time\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "2026-05-13T13:49:53Z",
+            "rfc3339": "2026-05-13T13:49:53Z"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0
+        }
+      ]
+    }
+  ]
+}
+`
+}
+
+// TestApp_applyAllDeletions_multipleStates covers issue #84: with several
+// tfstates, a moved block is removed only when the move has been applied in all
+// of them (AND semantics). A block still pending in any one state is preserved.
+func TestApp_applyAllDeletions_multipleStates(t *testing.T) {
+	movedBlock := []byte(`
+resource "time_static" "bbb" {}
+
+moved {
+  from = time_static.aaa
+  to   = time_static.bbb
+}
+`)
+	// The move is applied where "bbb" exists, and still pending where "aaa" does.
+	applied := stateWithResource("bbb")
+	pending := stateWithResource("aaa")
+
+	tests := []struct {
+		name   string
+		data   []byte
+		states []string
+		want   []byte
+	}{
+		{
+			name:   "applied in all states: remove",
+			data:   movedBlock,
+			states: []string{applied, applied},
+			want: []byte(`
+resource "time_static" "bbb" {}
+
+`),
+		},
+		{
+			name:   "pending in one state: keep",
+			data:   movedBlock,
+			states: []string{applied, pending},
+			want:   movedBlock,
+		},
+		{
+			name:   "pending in all states: keep",
+			data:   movedBlock,
+			states: []string{pending, pending},
+			want:   movedBlock,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := &App{
+				hclParser: hclparse.NewParser(),
+				CLI:       &CLI{},
+			}
+			var states []*tfstate.TFState
+			for _, s := range tt.states {
+				state, err := tfstate.Read(t.Context(), strings.NewReader(s))
+				if err != nil {
+					t.Fatal(err)
+				}
+				states = append(states, state)
+			}
+			got, err := app.applyAllDeletions(tt.data, states)
+			if err != nil {
+				t.Fatalf("applyAllDeletions() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("applyAllDeletions() got = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/removed_test.go
+++ b/removed_test.go
@@ -349,15 +349,15 @@ module "bbb" {
 				hclParser: tt.fields.hclParser,
 				CLI:       tt.fields.CLI,
 			}
-			var state *tfstate.TFState
+			var states []*tfstate.TFState
 			if tt.args.state != "" {
-				var err error
-				state, err = tfstate.Read(t.Context(), strings.NewReader(tt.args.state))
+				state, err := tfstate.Read(t.Context(), strings.NewReader(tt.args.state))
 				if err != nil {
 					t.Fatal(err)
 				}
+				states = append(states, state)
 			}
-			got, err := app.applyAllDeletions(tt.args.data, state)
+			got, err := app.applyAllDeletions(tt.args.data, states)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("applyAllDeletions() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Closes #84.

## Summary

Allow `--tfstate` to be passed multiple times so tfclean can consider several states backing the same Terraform config (e.g. per-developer, per-PR, dev/prod). A `moved`/`import`/`removed` block is removed **only when it has been applied in all of the given states**; a block still pending in any one of them is preserved.

Example — a `moved` block applied to `dev-alice` and `prod` but not yet to `dev-bob` is kept until it is applied everywhere:

```bash
tfclean \
  --tfstate s3://path/to/dev-alice.tfstate \
  --tfstate s3://path/to/dev-bob.tfstate \
  --tfstate s3://path/to/prod.tfstate \
  /path/to/tffiles
```

## Changes

- **cli.go**: `Tfstate` `string` → `[]string`. Single-flag usage (`--tfstate s3://...`) stays fully backward compatible.
- **app.go**: read all states in `Run`; a read failure on an explicitly given state is treated as **fatal** so a silently dropped state can't cause premature removal. The per-block applied checks are aggregated across states via a new `appliedInAll` helper (AND). Block-type-specific logic (`movedImportIsApplied`, etc.) is unchanged.
- **multiple_tfstate_test.go**: new test covering the AND behavior (applied-in-all → remove, pending-in-one → keep, pending-in-all → keep). Existing tests updated for the `[]*tfstate.TFState` signature.
- **README.md**: document multiple-tfstate usage and semantics.

## Backward compatibility

No breaking changes. A single `--tfstate` collapses to a one-element slice with identical behavior; omitting `--tfstate` still auto-detects a single S3 backend. Multiple states must be specified explicitly (auto-detection resolves only one backend).

## Verification

- `go build ./...` / `go test ./...` pass.
- End-to-end with the built binary: one-pending → block kept; all-applied → block removed; missing state → hard error.